### PR TITLE
Fixed User-Agent

### DIFF
--- a/DiscordClient.cs
+++ b/DiscordClient.cs
@@ -826,7 +826,7 @@ namespace DiscordUnity
             if (hasToken) httpRequest.Headers["authorization"] = isBot ? "Bot " + token : token;
             httpRequest.ContentType = "application/json";
             httpRequest.Method = "POST";
-            httpRequest.UserAgent = isBot ? "DiscordBot DiscordUnity" : "Custom Discord Client DiscordUnity";
+            httpRequest.UserAgent = "DiscordBot (https://github.com/robinhood128/DiscordUnity, 0.0.0)";
             httpRequest.BeginGetRequestStream(new AsyncCallback(OnRequestStream), new RequestStateJSON() { content = content, result = result, request = httpRequest });
         }
 
@@ -836,7 +836,7 @@ namespace DiscordUnity
             if (hasToken) httpRequest.Headers["authorization"] = isBot ? "Bot " + token : token;
             httpRequest.ContentType = "application/json";
             httpRequest.Method = "POST";
-            httpRequest.UserAgent = isBot ? "DiscordBot DiscordUnity" : "Custom Discord Client DiscordUnity";
+            httpRequest.UserAgent = "DiscordBot (https://github.com/robinhood128/DiscordUnity, 0.0.0)";
             httpRequest.BeginGetResponse(new AsyncCallback(OnGetResponse), new RequestState() { result = result, request = httpRequest });
         }
 
@@ -846,7 +846,7 @@ namespace DiscordUnity
             if (hasToken) httpRequest.Headers["authorization"] = isBot ? "Bot " + token : token;
             httpRequest.ContentType = "application/json";
             httpRequest.Method = "GET";
-            httpRequest.UserAgent = isBot ? "DiscordBot DiscordUnity" : "Custom Discord Client DiscordUnity";
+            httpRequest.UserAgent = "DiscordBot (https://github.com/robinhood128/DiscordUnity, 0.0.0)";
             httpRequest.BeginGetResponse(new AsyncCallback(OnGetResponse), new RequestState() { result = result, request = httpRequest });
         }
 
@@ -856,7 +856,7 @@ namespace DiscordUnity
             if (hasToken) httpRequest.Headers["authorization"] = isBot ? "Bot " + token : token;
             httpRequest.ContentType = "application/json";
             httpRequest.Method = "PATCH";
-            httpRequest.UserAgent = isBot ? "DiscordBot DiscordUnity" : "Custom Discord Client DiscordUnity";
+            httpRequest.UserAgent = "DiscordBot (https://github.com/robinhood128/DiscordUnity, 0.0.0)";
             httpRequest.BeginGetRequestStream(new AsyncCallback(OnRequestStream), new RequestStateJSON() { content = content, result = result, request = httpRequest });
         }
 
@@ -866,7 +866,7 @@ namespace DiscordUnity
             if (hasToken) httpRequest.Headers["authorization"] = isBot ? "Bot " + token : token;
             httpRequest.ContentType = "application/json";
             httpRequest.Method = "PUT";
-            httpRequest.UserAgent = isBot ? "DiscordBot DiscordUnity" : "Custom Discord Client DiscordUnity";
+            httpRequest.UserAgent = "DiscordBot (https://github.com/robinhood128/DiscordUnity, 0.0.0)";
             httpRequest.BeginGetRequestStream(new AsyncCallback(OnRequestStream), new RequestStateJSON() { content = content, result = result, request = httpRequest });
         }
 
@@ -876,7 +876,7 @@ namespace DiscordUnity
             if (hasToken) httpRequest.Headers["authorization"] = isBot ? "Bot " + token : token;
             httpRequest.ContentType = "application/json";
             httpRequest.Method = "PUT";
-            httpRequest.UserAgent = isBot ? "DiscordBot DiscordUnity" : "Custom Discord Client DiscordUnity";
+            httpRequest.UserAgent = "DiscordBot (https://github.com/robinhood128/DiscordUnity, 0.0.0)";
             httpRequest.BeginGetResponse(new AsyncCallback(OnGetResponse), new RequestState() { result = result, request = httpRequest });
         }
 
@@ -886,7 +886,7 @@ namespace DiscordUnity
             if (hasToken) httpRequest.Headers["authorization"] = isBot ? "Bot " + token : token;
             httpRequest.ContentType = "application/json";
             httpRequest.Method = "DELETE";
-            httpRequest.UserAgent = isBot ? "DiscordBot DiscordUnity" : "Custom Discord Client DiscordUnity";
+            httpRequest.UserAgent = "DiscordBot (https://github.com/robinhood128/DiscordUnity, 0.0.0)";
             httpRequest.BeginGetResponse(new AsyncCallback(OnGetResponse), new RequestState() { result = result, request = httpRequest });
         }
 


### PR DESCRIPTION
All user-agents have to be formatted as `DiscordBot ($githubUrl, $versionNumber)`, regardless of whether the account is a bot account or not.

P.S. Your HTTP wrapper is extremely boilerplate. Try having a base `Request` method. Also, why do you return void on every HTTP request? Most of the time the response contains a body which has info you need to use.
